### PR TITLE
fix enumerator if kfd path does not exist

### DIFF
--- a/rocm_agent_enumerator
+++ b/rocm_agent_enumerator
@@ -190,24 +190,25 @@ def readFromKFD():
   target_list = []
 
   topology_dir = '/sys/class/kfd/kfd/topology/nodes/'
-  for node in sorted(os.listdir(topology_dir)):
-    node_path = os.path.join(topology_dir, node)
-    if os.path.isdir(node_path):
-      prop_path = node_path + '/properties'
-      if os.path.isfile(prop_path):
-        target_search_term = re.compile("gfx_target_version.+")
-        with open(prop_path) as f:
-          line = f.readline()
-          while line != '' :
-            search_result = target_search_term.search(line)
-            if search_result is not None:
-              device_id = int(search_result.group(0).split(' ')[1], 10)
-              if device_id != 0:
-                major_ver = int((device_id / 10000) % 100)
-                minor_ver = int((device_id / 100) % 100)
-                stepping_ver = int(device_id % 100)
-                target_list.append("gfx" + format(major_ver, 'd') + format(minor_ver, 'x') + format(stepping_ver, 'x'))
+  if os.path.isdir(topology_dir):
+    for node in sorted(os.listdir(topology_dir)):
+      node_path = os.path.join(topology_dir, node)
+      if os.path.isdir(node_path):
+        prop_path = node_path + '/properties'
+        if os.path.isfile(prop_path):
+          target_search_term = re.compile("gfx_target_version.+")
+          with open(prop_path) as f:
             line = f.readline()
+            while line != '' :
+              search_result = target_search_term.search(line)
+              if search_result is not None:
+                device_id = int(search_result.group(0).split(' ')[1], 10)
+                if device_id != 0:
+                  major_ver = int((device_id / 10000) % 100)
+                  minor_ver = int((device_id / 100) % 100)
+                  stepping_ver = int(device_id % 100)
+                  target_list.append("gfx" + format(major_ver, 'd') + format(minor_ver, 'x') + format(stepping_ver, 'x'))
+              line = f.readline()
 
   return target_list
 


### PR DESCRIPTION
This solves the following issue:
```
Traceback (most recent call last):
  File "/opt/rocm/bin/rocm_agent_enumerator", line 257, in <module>
    main()
  File "/opt/rocm/bin/rocm_agent_enumerator", line 241, in main
    target_list = readFromKFD()
  File "/opt/rocm/bin/rocm_agent_enumerator", line 193, in readFromKFD
    for node in sorted(os.listdir(topology_dir)):
FileNotFoundError: [Errno 2] No such file or directory: '/sys/class/kfd/kfd/topology/nodes/'
```

and ensures that if the file does not exist, the program still continues and exists successfully.

Closes #56 