### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dayatsin-amd @shwetagkhatri


### PR DESCRIPTION
Creating the CODEOWNERS file for Rocminfo component. 

The CODEOWNERS file is used to define individuals or teams that are responsible for code in a repository.